### PR TITLE
Brexit nodeal

### DIFF
--- a/Trade/Commonwealth free trade.md
+++ b/Trade/Commonwealth free trade.md
@@ -4,9 +4,8 @@ We aim to create a free trade deal between the Commonwealth countries to be able
 
 ## Australia
 we already do a lot of trading with Australia it would be in our best interest to strike up a trade deal with them taking that 9.4% of our trade is done with them.
-
 ## Canada
-
+we one of the biggest trade Partners in Europe with Canada this makes sense that we would like to carry on a this trend when we're outside the European Union this would benefit both of us because
 ## New Zealand
 
 ## The Bahamas
@@ -24,4 +23,5 @@ we already do a lot of trading with Australia it would be in our best interest t
 
 ## Cameroon
 
-## Canada
+## India
+is an emerging market with great growth potential. trade deal with means that we will have cheap labour in our free trade union plus access to any free trade deals India may have.

--- a/Trade/Commonwealth free trade.md
+++ b/Trade/Commonwealth free trade.md
@@ -1,0 +1,27 @@
+We aim to create a free trade deal between the Commonwealth countries to be able to better support them
+
+##  Antigua and Barbuda
+
+## Australia
+we already do a lot of trading with Australia it would be in our best interest to strike up a trade deal with them taking that 9.4% of our trade is done with them.
+
+## Canada
+
+## New Zealand
+
+## The Bahamas
+
+
+## Bangladesh
+
+## Barbados
+
+## Belize
+
+## Botswana
+
+## Brunei
+
+## Cameroon
+
+## Canada


### PR DESCRIPTION
a change in policy to allow for a no-deal Brexit. add a new section to the policy out talking about trade. this is really just a contingency plan to be taken if we do fall out of the European Union.  the pirate parties official stance on Brexit is that the people should have another vote whether to stay or leave and on what deal if they do want to leave.